### PR TITLE
Restrict access to api/users endpoint

### DIFF
--- a/api/auth/authMiddleware.js
+++ b/api/auth/authMiddleware.js
@@ -1,0 +1,14 @@
+const jwt = require('jsonwebtoken');
+const secrets = require('../../config/secrets');
+
+function verifyToken(req, res, next) {
+    try {
+        const payload = jwt.verify(req.headers.authorization, secrets.jwtSecret);
+        req.tokenPayload = payload;
+        next();
+    } catch (e) {
+        res.status(401).json({ errorMessage: 'Invalid token' });
+    }
+}
+
+module.exports = { verifyToken };


### PR DESCRIPTION
Send JSON web token upon successful POST request to /api/auth/login endpoint

Require authorization header with value of token to be sent in response to all requests made to endpoints in userRouter.js

Respond with 401 status to requests made to endpoints in userRouter.js when username in decoded authorization token payload does not equal username in route parameters as happens if user tries to edit account of another user